### PR TITLE
Add WIDOCO hash-navigation patch for bare local-name fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *-Schema.ttl
 *.ppt*
-tools/*.jar
+tools/**/*.jar
+__pycache__/
+*.pyc
 .claude/settings.local.json

--- a/docs/gist-14.1/widoco-documentation/index-en.html
+++ b/docs/gist-14.1/widoco-documentation/index-en.html
@@ -24,10 +24,15 @@
     <script> 
 function loadHash() {
   jQuery(".markdown").each(function(el){jQuery(this).after(marked.parse(jQuery(this).text())).remove()});
-	var hash = location.hash;
-	if($(hash).offset()!=null){
-	  $('html, body').animate({scrollTop: $(hash).offset().top}, 0);
-}
+	var hash = decodeURIComponent(location.hash.slice(1));
+	var target = hash && (
+	  document.getElementById(hash) ||
+	  document.getElementById("https://w3id.org/semanticarts/ns/ontology/gist/" + hash) ||
+	  document.getElementById("https://w3id.org/semanticarts/ns/data/gist/" + hash)
+	);
+	if(target){
+	  $('html, body').animate({scrollTop: $(target).offset().top}, 0);
+	}
 	loadTOC();
 }
 function loadTOC(){

--- a/docs/gist-14.1/widoco.command.txt
+++ b/docs/gist-14.1/widoco.command.txt
@@ -1,1 +1,1 @@
-java -jar ../tools/widoco-1.4.25-jar-with-dependencies_JDK-17.jar -ontURI https://w3id.org/semanticarts/ontology/gistCore14.1.0 -outFolder ./widoco-documentation -confFile ./widoco_config.txt -oops -webVowl -licensius -excludeIntroduction
+java -jar ../../tools/widoco-1.4.25-jar-with-dependencies_JDK-17.jar -ontURI https://w3id.org/semanticarts/ontology/gistCore14.1.0 -outFolder ./widoco-documentation -confFile ./widoco_config.txt -oops -webVowl -licensius -excludeIntroduction

--- a/tools/BUILDING.md
+++ b/tools/BUILDING.md
@@ -24,6 +24,14 @@ cd docs/gist-<version>
 bash widoco.command.txt
 ```
 
+Then apply the hash-navigation patch (from the repo root):
+
+```bash
+python3 tools/patch_widoco_hash.py docs/gist-<version>/widoco-documentation/index-en.html
+```
+
+This patches `loadHash()` so that bare local-name fragments (e.g. `#Address`) resolve correctly. The script is idempotent and exits non-zero if the expected stock function is not found.
+
 Output lands in `docs/gist-<version>/widoco-documentation/`. To smoke-test it locally:
 
 ```bash
@@ -31,6 +39,12 @@ Output lands in `docs/gist-<version>/widoco-documentation/`. To smoke-test it lo
 ```
 
 then open http://127.0.0.1:8000/index-en.html.
+
+Alternatively, `tools/test-build.sh` runs all three steps (fetch jar, run WIDOCO, apply patch) in one go from the repo root:
+
+```bash
+bash tools/test-build.sh <version>   # e.g. bash tools/test-build.sh 14.1
+```
 
 ## Starting a new release
 

--- a/tools/BUILDING.md
+++ b/tools/BUILDING.md
@@ -40,10 +40,10 @@ Output lands in `docs/gist-<version>/widoco-documentation/`. To smoke-test it lo
 
 then open http://127.0.0.1:8000/index-en.html.
 
-Alternatively, `tools/test-build.sh` runs all three steps (fetch jar, run WIDOCO, apply patch) in one go from the repo root:
+Alternatively, `tools/build.sh` runs all three steps (fetch jar, run WIDOCO, apply patch) in one go from the repo root:
 
 ```bash
-bash tools/test-build.sh <version>   # e.g. bash tools/test-build.sh 14.1
+bash tools/build.sh <version>   # e.g. bash tools/build.sh 14.1
 ```
 
 ## Starting a new release

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Test the full WIDOCO build + hash patch for a gist release.
-# Run from the repo root: bash tools/test-build.sh <version>
-# Example: bash tools/test-build.sh 14.1
+# Build WIDOCO documentation and apply the hash-navigation patch for a gist release.
+# Run from the repo root: bash tools/build.sh <version>
+# Example: bash tools/build.sh 14.1
 set -euo pipefail
 
 VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
-  echo "usage: bash tools/test-build.sh <version>  (e.g. 14.1)" >&2
+  echo "usage: bash tools/build.sh <version>  (e.g. 14.1)" >&2
   exit 1
 fi
 
@@ -28,4 +28,4 @@ python3 tools/patch_widoco_hash.py "${RELEASE_DIR}/widoco-documentation/index-en
 echo ""
 echo "Build complete. To smoke-test, run:"
 echo "  python -m http.server 8000 --directory ${RELEASE_DIR}/widoco-documentation"
-echo "Then open: http://127.0.0.1:8000/index-en.html#Address"
+echo "Then open: http://localhost:8000/index-en.html#Address"

--- a/tools/patch_widoco_hash.py
+++ b/tools/patch_widoco_hash.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Post-process WIDOCO output so bare local-name fragments (e.g. #Address)
+resolve to anchors whose id is the full gist IRI. Run after WIDOCO."""
+import re
+import sys
+from pathlib import Path
+
+# Must match the IRIs WIDOCO emits as anchor id="..." values.
+ONTOLOGY_NS = "https://w3id.org/semanticarts/ns/ontology/gist/"
+DATA_NS = "https://w3id.org/semanticarts/ns/data/gist/"
+
+PATCHED = (
+    'var hash = decodeURIComponent(location.hash.slice(1));\n'
+    '\tvar target = hash && (\n'
+    '\t  document.getElementById(hash) ||\n'
+    f'\t  document.getElementById("{ONTOLOGY_NS}" + hash) ||\n'
+    f'\t  document.getElementById("{DATA_NS}" + hash)\n'
+    '\t);\n'
+    '\tif(target){\n'
+    "\t  $('html, body').animate({scrollTop: $(target).offset().top}, 0);\n"
+    '\t}'
+)
+
+# Matches the stock WIDOCO hash-handling block (whitespace-tolerant).
+STOCK = re.compile(
+    r"var\s+hash\s*=\s*location\.hash;\s*"
+    r"if\(\$\(hash\)\.offset\(\)\s*!=\s*null\)\s*\{\s*"
+    r"\$\('html, body'\)\.animate\(\{scrollTop:\s*\$\(hash\)\.offset\(\)\.top\},\s*0\);\s*"
+    r"\}",
+    re.DOTALL,
+)
+
+def patch(path: Path) -> bool:
+    html = path.read_text(encoding="utf-8")
+    if "decodeURIComponent(location.hash" in html:
+        print(f"{path}: already patched, skipping")
+        return True
+    new_html, n = STOCK.subn(PATCHED, html, count=1)
+    if n != 1:
+        print(f"ERROR: stock loadHash block not found in {path}. "
+              "WIDOCO output format may have changed; update patch_widoco_hash.py.",
+              file=sys.stderr)
+        return False
+    path.write_text(new_html, encoding="utf-8")
+    print(f"{path}: patched hash navigation")
+    return True
+
+if __name__ == "__main__":
+    files = [Path(a) for a in sys.argv[1:]]
+    if not files:
+        print("usage: patch_widoco_hash.py <generated-index.html> [...]", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(0 if all(patch(f) for f in files) else 1)

--- a/tools/test-build.sh
+++ b/tools/test-build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Test the full WIDOCO build + hash patch for a gist release.
+# Run from the repo root: bash tools/test-build.sh <version>
+# Example: bash tools/test-build.sh 14.1
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "usage: bash tools/test-build.sh <version>  (e.g. 14.1)" >&2
+  exit 1
+fi
+
+RELEASE_DIR="docs/gist-${VERSION}"
+if [[ ! -d "$RELEASE_DIR" ]]; then
+  echo "ERROR: directory '$RELEASE_DIR' not found" >&2
+  exit 1
+fi
+
+echo "==> Fetching WIDOCO jar if needed..."
+bash tools/fetch-widoco.sh
+
+echo "==> Running WIDOCO for gist-${VERSION}..."
+(cd "$RELEASE_DIR" && bash widoco.command.txt)
+
+echo "==> Applying hash-navigation patch..."
+python3 tools/patch_widoco_hash.py "${RELEASE_DIR}/widoco-documentation/index-en.html"
+
+echo ""
+echo "Build complete. To smoke-test, run:"
+echo "  python -m http.server 8000 --directory ${RELEASE_DIR}/widoco-documentation"
+echo "Then open: http://127.0.0.1:8000/index-en.html#Address"


### PR DESCRIPTION
 ⚠️  Draft — depends on PR #37 

  ## Summary
  
  - Add `tools/patch_widoco_hash.py` — patches WIDOCO-generated `index-en.html` so bare local-name
  fragments (e.g. `#Address`) resolve to the correct anchors, whose `id` is the full gist IRI
  - Apply patch to `docs/gist-14.1/widoco-documentation/index-en.html`
  - Add `tools/build.sh` to run the full pipeline (fetch jar, run WIDOCO, apply patch) in one step
  - Update `tools/BUILDING.md` to document the patch step and `build.sh`
  - Fix `docs/gist-14.1/widoco.command.txt` jar path to reflect the new `docs/` folder structure

  ## Test plan
  
  - [ ] Run `bash tools/build.sh 14.1` from the repo root
  - [ ] Open `http://localhost:8000/index-en.html#Address` and confirm the page scrolls to the Address
  entity
  - [ ] Run the patch script a second time and confirm it prints "already patched, skipping"

Closes #36 
