### PR TITLE
Add JavaScript redirect to latest WIDOCO documentation

### DIFF
--- a/docs/latest/index.html
+++ b/docs/latest/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>gist WIDOCO Documentation (latest)</title>
+<script>
+  var hash = window.location.hash;
+  window.location.replace("../gist-14.1/widoco-documentation/index-en.html" + hash);
+</script>
+</head>
+<body>
+<p>Redirecting to the latest gist WIDOCO documentation&hellip;</p>
+</body>
+</html>


### PR DESCRIPTION
 ⚠️  Draft — depends on #37. 
 Requires an update in docs/latest/index.html for each release. This should be documented in https://semarts.atlassian.net/wiki/x/WwApQw

  ## Summary
  
  Adds `docs/latest/index.html` — a stable URL that always redirects to the most recent WIDOCO
  documentation, preserving the URL fragment (e.g. `#Address`) via JavaScript. This supports IRI
  dereferencing via w3id.org without requiring `.htaccess` changes on each new gist release.
  
  ## Test plan

  - [ ] Open `https://semanticarts.github.io/gist-doc/latest/#Address` and confirm it redirects to the
  gist-14.1 WIDOCO docs scrolled to the Address entity
  - [ ] Confirm the redirect preserves the fragment for other entity names

Closes #39