### PR TITLE
htaccess test harness: Windows Git Bash fix + live/origin resolution checks

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "MD024": { "siblings_only": true }
+}

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -1,12 +1,30 @@
 # Testing `semanticarts.htaccess`
 
-These tests let you validate `semanticarts.htaccess` on your own machine
-**before** copying it into the [w3id.org](https://github.com/perma-id/w3id.org)
-repo's `semanticarts/` folder. w3id.org runs Apache, so the only faithful way to
-test the rewrite logic is to run Apache against the file — which `run-tests.sh`
-does inside a throwaway container.
+Two complementary harnesses validate `semanticarts.htaccess` — the rewrite file
+deployed to the [w3id.org](https://github.com/perma-id/w3id.org) repo's
+`semanticarts/` folder:
 
-## What it checks
+- **`run-tests.sh`** — run it **before** deploying. It checks the **routing
+  logic offline**: the status code and `Location` each content-negotiation
+  branch produces (the first redirect hop only). w3id.org runs Apache, so the
+  only faithful way to test the rewrite logic is to run Apache against the file
+  — this stands up a throwaway `httpd:2.4` container and drives the real rules
+  with `curl`. No internet needed after the image is pulled once.
+- **`check-live-deref.sh`** — run it **after** deploying. It checks that the
+  live IRIs actually **resolve end to end**: it follows every redirect to a
+  final `200` whose body parses in the negotiated format. This catches breakage
+  the offline test structurally cannot — a correct redirect pointing at a
+  destination that doesn't exist.
+
+Use both: `run-tests.sh` proves the rules are written correctly; then, once the
+`.htaccess` is live on w3id.org, `check-live-deref.sh` proves the things they
+point at are actually published.
+
+---
+
+## `run-tests.sh` — offline routing checks (pre-deploy)
+
+### What it checks
 
 `run-tests.sh` starts `httpd:2.4` with the htaccess loaded as a per-directory
 `.htaccess` at the document root — the same context it has under w3id.org's
@@ -28,59 +46,16 @@ header** without following the redirect:
 - The catch-all (anything else, e.g. the `ns/data/gist/` namespace) → 303 to a
   Turtle file on the Semantic Arts server, preserving the request path.
 
-## Live deref regression test (`check-live-deref.sh`)
+It asserts the **redirect targets**, not that those targets resolve — that is
+what `check-live-deref.sh` is for.
 
-`run-tests.sh` checks only the **first redirect hop**, offline, against a local
-Apache. That cannot catch the `/gistCore.rdf` incident: the `.htaccess` redirect
-fired correctly (a valid 303/302 `Location`, so `run-tests.sh` passed), but the
-**final destination** on `ontologies.semanticarts.com` 404'd because the
-unversioned "latest" alias file was never published there. Checking only the hop
-— or only the per-term files on GitHub Pages — misses it.
+### Requirements
 
-`check-live-deref.sh` closes that gap. It hits the **real** IRIs on w3id.org,
-**follows every redirect to completion**, and asserts a final **200 whose body
-actually parses** in the negotiated format (via `rdflib`/`jq` when available). It
-targets the **unversioned** alias (`…/ontology/gistCore`) — the resource that
-went missing — and pairs each with the **versioned** pass-through
-(`gistCore14.1.0.{ttl,rdf,jsonld}`) as a control.
-
-If an unversioned case 404s at the final hop **while its versioned control still
-resolves**, that is the exact incident signature and is flagged as
-`SIGNATURE  unversioned latest alias missing on ontologies.semanticarts.com:
-<name>` — distinct from a generic redirect-rule break (which would fail the
-versioned case too).
-
-```bash
-tools/htaccess-test/check-live-deref.sh                        # gistCore, v14.1.0
-NAMES="gistCore gistMediaTypes" tools/htaccess-test/check-live-deref.sh
-VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
-```
-
-- Needs **internet**, not Docker or the `HTACCESS` file — it tests the *deployed*
-  rules, so run it after a w3id.org change lands. Good as a CI/cron canary.
-- Env: `NAMES` (space-separated modules, default `gistCore`), `VERSION` (default
-  `14.1.0`), `IRI_BASE`, `TIMEOUT`, `PYTHON` (interpreter with rdflib; see below).
-- Body validators are **optional**: `rdflib` (Turtle/RDF-XML/JSON-LD,
-  `pip install rdflib`) or `jq` (JSON-LD only). Missing validators downgrade a
-  body check to `PASS*`/`WARN`, never a FAIL. The script probes `python3`,
-  `python`, then the Windows `py` launcher and keeps the first that can
-  `import rdflib`. When several Pythons coexist and the one on PATH lacks rdflib
-  (e.g. MSYS2's `python` vs a native `C:\Python` install), point `PYTHON` at the
-  right one: `PYTHON=/c/Python/Python313/python.exe ...check-live-deref.sh`.
-- Exit codes: `0` all passed · `1` a real failure (final 404, bad body, or the
-  signature) · `2` could not run (w3id.org itself unreachable). Cases that are
-  **network-unreachable** (e.g. a firewalled runner with no route to GitHub
-  Pages, which the HTML branch redirects to) are reported as **WARN**, not FAIL,
-  so they don't cause spurious failures.
-
-## Requirements
-
-- Docker (running) — for `run-tests.sh` only
+- Docker (running)
 - `curl`
 
 The first run pulls the `httpd:2.4` image (needs internet once). After that the
-routing tests run fully offline — they assert the **redirect targets**, not that
-those targets resolve.
+routing tests run fully offline.
 
 ### Windows / Git Bash
 
@@ -93,7 +68,7 @@ and translates the host path with `cygpath` for the `docker` calls, so no manual
 setup is needed. Docker Desktop must be running on the host (not inside a dev
 container).
 
-## Run
+### Run
 
 `semanticarts.htaccess` is intentionally **not** stored in this repo — it lives
 in the [w3id.org](https://github.com/perma-id/w3id.org) repo's
@@ -112,7 +87,7 @@ HTACCESS=../w3id.org/semanticarts/.htaccess CHECK_TARGETS=1 tools/htaccess-test/
 
 Exit code is `0` only when every check passes, so it works in CI too.
 
-### Useful overrides
+#### Useful overrides
 
 - `HTACCESS` (**required**) — path to the `semanticarts.htaccess` under test
   (relative or absolute; typically `../w3id.org/semanticarts/.htaccess`).
@@ -120,7 +95,7 @@ Exit code is `0` only when every check passes, so it works in CI too.
 - `PAGES_BASE` (default `https://semanticarts.github.io/gist-doc`) — expected redirect base / target host.
 - `CHECK_TARGETS` (default `0`) — `1` = also verify the live Pages files resolve (200).
 
-## No Docker? Two fallbacks
+### No Docker? Two fallbacks
 
 1. **Direct Pages reachability only** — skips the rewrite logic but confirms the
    files the rules point at are actually published:
@@ -137,13 +112,93 @@ Exit code is `0` only when every check passes, so it works in CI too.
    `AllowOverride All` and `mod_rewrite` enabled, then run the same `curl`
    assertions from `run-tests.sh` against it.
 
-## After it passes
+---
 
-Copy `semanticarts.htaccess` into the w3id.org repo's `semanticarts/.htaccess`,
-open the PR there, and once merged re-run the conneg checks against the real
-IRIs:
+## `check-live-deref.sh` — live resolution checks (post-deploy)
+
+### Why it exists
+
+The offline `run-tests.sh` asserts the redirect **target** (`Location`), not
+that the target resolves. The `/gistCore.rdf` incident slipped through exactly
+there: the `.htaccess` redirect fired correctly (a valid 303/302 `Location`, so
+`run-tests.sh` passed), but the **final destination** on
+`ontologies.semanticarts.com` 404'd because the unversioned "latest" alias file
+was never published. Checking only the hop — or only the per-term files on
+GitHub Pages — misses it.
+
+### What it checks
+
+`check-live-deref.sh` hits the **real** IRIs on w3id.org, **follows every
+redirect to completion**, and asserts a final **200 whose body actually parses**
+in the negotiated format (via `rdflib`/`jq` when available). It targets the
+**unversioned** alias (`…/ontology/gistCore`) — the resource that went missing —
+and pairs each with the **versioned** pass-through
+(`gistCore14.1.0.{ttl,rdf,jsonld}`) as a control.
+
+If an unversioned case 404s at the final hop **while its versioned control still
+resolves**, that is the exact incident signature and is flagged as
+`SIGNATURE  unversioned latest alias missing on ontologies.semanticarts.com:
+<name>` — distinct from a generic redirect-rule break (which would fail the
+versioned case too).
+
+### Requirements
+
+- `curl`
+- Internet access to w3id.org, `ontologies.semanticarts.com`, and (for the
+  HTML/WIDOCO branch) `semanticarts.github.io`.
+- **Optional** body validators — `rdflib` (Turtle/RDF-XML/JSON-LD,
+  `pip install rdflib`) or `jq` (JSON-LD only). Missing validators downgrade a
+  body check to `PASS*`/`WARN`, never a FAIL. The script probes `python3`,
+  `python`, then the Windows `py` launcher and keeps the first that can
+  `import rdflib`. When several Pythons coexist and the one on PATH lacks rdflib
+  (e.g. MSYS2's `python` vs a native `C:\Python` install), point `PYTHON` at the
+  right one: `PYTHON=/c/Python/Python313/python.exe ...check-live-deref.sh`.
+
+It needs neither Docker nor the `HTACCESS` file — it tests the *deployed* rules,
+so run it after a w3id.org change lands. Good as a CI/cron canary.
+
+### Run
 
 ```bash
+tools/htaccess-test/check-live-deref.sh                        # gistCore, v14.1.0
+NAMES="gistCore gistMediaTypes" tools/htaccess-test/check-live-deref.sh
+VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
+```
+
+#### Useful overrides
+
+- `NAMES` (default `gistCore`) — space-separated ontology modules to check, so
+  the same alias-gap test covers any module, not just `gistCore`.
+- `VERSION` (default `14.1.0`) — release version for the versioned control cases.
+- `IRI_BASE` (default `https://w3id.org/semanticarts/ontology`).
+- `TIMEOUT` (default `20`) — per-request curl timeout, seconds.
+- `PYTHON` — path/name of a Python interpreter that has `rdflib` (see
+  Requirements).
+
+#### Exit codes
+
+- `0` — all checks passed.
+- `1` — a real failure (final 404, body did not parse, or the alias-missing
+  signature).
+- `2` — could not run (w3id.org itself unreachable).
+
+Cases that are **network-unreachable** (e.g. a firewalled runner with no route
+to GitHub Pages, which the HTML branch redirects to) are reported as **WARN**,
+not FAIL, so they don't cause spurious failures.
+
+---
+
+## Deploying to w3id.org
+
+Once `run-tests.sh` passes, copy `semanticarts.htaccess` into the w3id.org repo's
+`semanticarts/.htaccess` and open the PR there. After it merges and GitHub Pages
+has redeployed, confirm the live IRIs resolve end to end:
+
+```bash
+# Whole-ontology aliases (unversioned + versioned), following redirects to 200:
+tools/htaccess-test/check-live-deref.sh
+
+# Spot-check a single per-term IRI by hand (not covered by the script above):
 curl -sI -H 'Accept: text/turtle' \
   https://w3id.org/semanticarts/ns/ontology/gist/Account
 # expect: 303 + Location: https://semanticarts.github.io/gist-doc/terms/Account.ttl

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -10,15 +10,22 @@ deployed to the [w3id.org](https://github.com/perma-id/w3id.org) repo's
   only faithful way to test the rewrite logic is to run Apache against the file
   — this stands up a throwaway `httpd:2.4` container and drives the real rules
   with `curl`. No internet needed after the image is pulled once.
-- **`check-live-deref.sh`** — run it **after** deploying. It checks that the
-  live IRIs actually **resolve end to end**: it follows every redirect to a
-  final `200` whose body parses in the negotiated format. This catches breakage
-  the offline test structurally cannot — a correct redirect pointing at a
-  destination that doesn't exist.
+- **`check-live-deref.sh`** — verifies the whole-ontology files the rules point
+  at actually **exist and resolve**, in two modes:
+  - **`MODE=targets`** (**before** deploying) — hits the origin files directly
+    on `ontologies.semanticarts.com` (`gistCore.rdf`, `.ttl`, `.jsonld`, the
+    versioned files, the WIDOCO docs) and confirms each exists and parses. This
+    answers *"do the destinations the new rules will point at exist yet?"* —
+    which you cannot ask through w3id.org, because the new rules aren't live.
+  - **`MODE=deref`** (default, **after** deploying) — hits the real w3id.org
+    IRIs, follows every redirect to a final `200`, and validates the body. This
+    catches breakage the offline routing test structurally cannot — a correct
+    redirect pointing at a destination that doesn't exist.
 
-Use both: `run-tests.sh` proves the rules are written correctly; then, once the
-`.htaccess` is live on w3id.org, `check-live-deref.sh` proves the things they
-point at are actually published.
+Use all three checks across the deploy: `run-tests.sh` proves the rules are
+written correctly and `check-live-deref.sh MODE=targets` proves their
+destinations exist — **both before deploying**; then, once the `.htaccess` is
+live on w3id.org, `check-live-deref.sh` (deref) proves the full chain resolves.
 
 ---
 
@@ -114,7 +121,7 @@ Exit code is `0` only when every check passes, so it works in CI too.
 
 ---
 
-## `check-live-deref.sh` — live resolution checks (post-deploy)
+## `check-live-deref.sh` — whole-ontology resolution checks
 
 ### Why it exists
 
@@ -128,24 +135,31 @@ GitHub Pages — misses it.
 
 ### What it checks
 
-`check-live-deref.sh` hits the **real** IRIs on w3id.org, **follows every
-redirect to completion**, and asserts a final **200 whose body actually parses**
-in the negotiated format (via `rdflib`/`jq` when available). It targets the
-**unversioned** alias (`…/ontology/gistCore`) — the resource that went missing —
-and pairs each with the **versioned** pass-through
-(`gistCore14.1.0.{ttl,rdf,jsonld}`) as a control.
+It verifies the whole-ontology files — the **unversioned** alias (`gistCore.*`),
+the resource that went missing, paired with the **versioned** file
+(`gistCore14.1.0.*`) as a control — in two modes:
 
-If an unversioned case 404s at the final hop **while its versioned control still
-resolves**, that is the exact incident signature and is flagged as
+- **`MODE=targets`** (pre-deploy) — requests each origin file **directly** on
+  `ontologies.semanticarts.com` (`gistCore.rdf`, `.ttl`, `.jsonld`, the versioned
+  files, and the WIDOCO docs) and asserts a `200` whose body parses. Run it
+  *before* deploying to confirm the destinations the new rules will point at
+  actually exist.
+- **`MODE=deref`** (default, post-deploy) — hits the **real** IRIs on w3id.org,
+  **follows every redirect to completion**, and asserts a final `200` whose body
+  parses in the negotiated format. Run it *after* deploying to confirm the rule
+  and its destination resolve together.
+
+In either mode, if an unversioned file is missing (404) **while its versioned
+control still resolves**, that is the exact incident signature and is flagged as
 `SIGNATURE  unversioned latest alias missing on ontologies.semanticarts.com:
 <name>` — distinct from a generic redirect-rule break (which would fail the
-versioned case too).
+versioned case too). Body parsing uses `rdflib`/`jq` when available.
 
 ### Requirements
 
 - `curl`
-- Internet access to w3id.org, `ontologies.semanticarts.com`, and (for the
-  HTML/WIDOCO branch) `semanticarts.github.io`.
+- Internet access to `ontologies.semanticarts.com` and `semanticarts.github.io`
+  (targets mode), plus w3id.org (deref mode).
 - **Optional** body validators — `rdflib` (Turtle/RDF-XML/JSON-LD,
   `pip install rdflib`) or `jq` (JSON-LD only). Missing validators downgrade a
   body check to `PASS*`/`WARN`, never a FAIL. The script probes `python3`,
@@ -154,23 +168,31 @@ versioned case too).
   (e.g. MSYS2's `python` vs a native `C:\Python` install), point `PYTHON` at the
   right one: `PYTHON=/c/Python/Python313/python.exe ...check-live-deref.sh`.
 
-It needs neither Docker nor the `HTACCESS` file — it tests the *deployed* rules,
-so run it after a w3id.org change lands. Good as a CI/cron canary.
+It needs neither Docker nor the `HTACCESS` file. Good as a CI/cron canary.
 
 ### Run
 
 ```bash
+# Pre-deploy: do the origin files the new rules will point at exist?
+MODE=targets tools/htaccess-test/check-live-deref.sh
+MODE=targets NAMES="gistCore gistMediaTypes" tools/htaccess-test/check-live-deref.sh
+
+# Post-deploy: does the live w3id.org chain resolve end to end?
 tools/htaccess-test/check-live-deref.sh                        # gistCore, v14.1.0
-NAMES="gistCore gistMediaTypes" tools/htaccess-test/check-live-deref.sh
-VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
+VERSION=14.1.0 NAMES=gistCore tools/htaccess-test/check-live-deref.sh
 ```
 
 #### Useful overrides
 
+- `MODE` (default `deref`) — `targets` = pre-deploy direct origin check;
+  `deref` = post-deploy w3id.org resolution.
 - `NAMES` (default `gistCore`) — space-separated ontology modules to check, so
   the same alias-gap test covers any module, not just `gistCore`.
 - `VERSION` (default `14.1.0`) — release version for the versioned control cases.
-- `IRI_BASE` (default `https://w3id.org/semanticarts/ontology`).
+- `IRI_BASE` (default `https://w3id.org/semanticarts/ontology`) — deref base.
+- `TARGET_BASE` (default `https://ontologies.semanticarts.com/ontology`) — origin
+  whole-ontology directory checked in targets mode.
+- `HTML_TARGET` — the WIDOCO docs URL the HTML branch resolves to.
 - `TIMEOUT` (default `20`) — per-request curl timeout, seconds.
 - `PYTHON` — path/name of a Python interpreter that has `rdflib` (see
   Requirements).
@@ -178,28 +200,39 @@ VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
 #### Exit codes
 
 - `0` — all checks passed.
-- `1` — a real failure (final 404, body did not parse, or the alias-missing
-  signature).
-- `2` — could not run (w3id.org itself unreachable).
+- `1` — a real failure (404, body did not parse, or the alias-missing signature).
+- `2` — could not run (base host unreachable).
 
 Cases that are **network-unreachable** (e.g. a firewalled runner with no route
-to GitHub Pages, which the HTML branch redirects to) are reported as **WARN**,
+to GitHub Pages, which the HTML branch resolves to) are reported as **WARN**,
 not FAIL, so they don't cause spurious failures.
 
 ---
 
 ## Deploying to w3id.org
 
-Once `run-tests.sh` passes, copy `semanticarts.htaccess` into the w3id.org repo's
-`semanticarts/.htaccess` and open the PR there. After it merges and GitHub Pages
-has redeployed, confirm the live IRIs resolve end to end:
+1. **Validate the rules offline** — `run-tests.sh` passes (routing is correct).
+2. **Confirm the destinations exist** — before deploying, check that the origin
+   files the new rules will point at are actually published:
 
-```bash
-# Whole-ontology aliases (unversioned + versioned), following redirects to 200:
-tools/htaccess-test/check-live-deref.sh
+   ```bash
+   MODE=targets tools/htaccess-test/check-live-deref.sh
+   ```
 
-# Spot-check a single per-term IRI by hand (not covered by the script above):
-curl -sI -H 'Accept: text/turtle' \
-  https://w3id.org/semanticarts/ns/ontology/gist/Account
-# expect: 303 + Location: https://semanticarts.github.io/gist-doc/terms/Account.ttl
-```
+   If this flags the alias-missing `SIGNATURE`, publish the missing
+   whole-ontology file(s) on `ontologies.semanticarts.com` **before** deploying —
+   otherwise you ship a rule that resolves to a 404 (the `/gistCore.rdf`
+   incident).
+3. **Deploy** — copy `semanticarts.htaccess` into the w3id.org repo's
+   `semanticarts/.htaccess` and open the PR there.
+4. **Confirm the live chain** — after it merges and GitHub Pages has redeployed:
+
+   ```bash
+   # Whole-ontology aliases (unversioned + versioned), following redirects to 200:
+   tools/htaccess-test/check-live-deref.sh
+
+   # Spot-check a single per-term IRI by hand (not covered by the script above):
+   curl -sI -H 'Accept: text/turtle' \
+     https://w3id.org/semanticarts/ns/ontology/gist/Account
+   # expect: 303 + Location: https://semanticarts.github.io/gist-doc/terms/Account.ttl
+   ```

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -28,9 +28,51 @@ header** without following the redirect:
 - The catch-all (anything else, e.g. the `ns/data/gist/` namespace) → 303 to a
   Turtle file on the Semantic Arts server, preserving the request path.
 
+## Live deref regression test (`check-live-deref.sh`)
+
+`run-tests.sh` checks only the **first redirect hop**, offline, against a local
+Apache. That cannot catch the `/gistCore.rdf` incident: the `.htaccess` redirect
+fired correctly (a valid 303/302 `Location`, so `run-tests.sh` passed), but the
+**final destination** on `ontologies.semanticarts.com` 404'd because the
+unversioned "latest" alias file was never published there. Checking only the hop
+— or only the per-term files on GitHub Pages — misses it.
+
+`check-live-deref.sh` closes that gap. It hits the **real** IRIs on w3id.org,
+**follows every redirect to completion**, and asserts a final **200 whose body
+actually parses** in the negotiated format (via `rdflib`/`jq` when available). It
+targets the **unversioned** alias (`…/ontology/gistCore`) — the resource that
+went missing — and pairs each with the **versioned** pass-through
+(`gistCore14.1.0.{ttl,rdf,jsonld}`) as a control.
+
+If an unversioned case 404s at the final hop **while its versioned control still
+resolves**, that is the exact incident signature and is flagged as
+`SIGNATURE  unversioned latest alias missing on ontologies.semanticarts.com:
+<name>` — distinct from a generic redirect-rule break (which would fail the
+versioned case too).
+
+```bash
+tools/htaccess-test/check-live-deref.sh                        # gistCore, v14.1.0
+NAMES="gistCore gistMediaTypes" tools/htaccess-test/check-live-deref.sh
+VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
+```
+
+- Needs **internet**, not Docker or the `HTACCESS` file — it tests the *deployed*
+  rules, so run it after a w3id.org change lands. Good as a CI/cron canary.
+- Env: `NAMES` (space-separated modules, default `gistCore`), `VERSION` (default
+  `14.1.0`), `IRI_BASE`, `TIMEOUT`.
+- Body validators are **optional**: `rdflib` under `python3`/`python`
+  (Turtle/RDF-XML/JSON-LD, `pip install rdflib`) or `jq` (JSON-LD only). Missing
+  validators downgrade a body check to `PASS*`/`WARN`, never a FAIL. On
+  Windows/Git Bash the interpreter is usually `python`, which is detected too.
+- Exit codes: `0` all passed · `1` a real failure (final 404, bad body, or the
+  signature) · `2` could not run (w3id.org itself unreachable). Cases that are
+  **network-unreachable** (e.g. a firewalled runner with no route to GitHub
+  Pages, which the HTML branch redirects to) are reported as **WARN**, not FAIL,
+  so they don't cause spurious failures.
+
 ## Requirements
 
-- Docker (running)
+- Docker (running) — for `run-tests.sh` only
 - `curl`
 
 The first run pulls the `httpd:2.4` image (needs internet once). After that the

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -36,26 +36,40 @@ The first run pulls the `httpd:2.4` image (needs internet once). After that the
 routing tests run fully offline — they assert the **redirect targets**, not that
 those targets resolve.
 
+### Windows / Git Bash
+
+`run-tests.sh` runs on Windows under Git Bash (MSYS/MINGW). It handles the MSYS
+quirk where the shell rewrites Unix-style arguments into Windows paths — left
+unhandled, that mangles the container-side bind-mount target
+(`/usr/local/apache2/htdocs/.htaccess`) and Apache never loads the rules, so
+every request 404s. The script disables that conversion (`MSYS_NO_PATHCONV=1`)
+and translates the host path with `cygpath` for the `docker` calls, so no manual
+setup is needed. Docker Desktop must be running on the host (not inside a dev
+container).
+
 ## Run
 
 `semanticarts.htaccess` is intentionally **not** stored in this repo — it lives
-in the [w3id.org](https://github.com/perma-id/w3id.org) repo. Point the harness
-at your working copy with `HTACCESS`:
+in the [w3id.org](https://github.com/perma-id/w3id.org) repo's
+`semanticarts/.htaccess`. Point the harness at your working copy with
+`HTACCESS`. Relative or absolute paths both work (the script resolves it to an
+absolute path before mounting it into the container):
 
 ```bash
-# Routing logic only:
-HTACCESS=/path/to/semanticarts.htaccess tools/htaccess-test/run-tests.sh
+# Routing logic only (path is relative to your current directory):
+HTACCESS=../w3id.org/semanticarts/.htaccess tools/htaccess-test/run-tests.sh
 
 # Also confirm the live gist-doc Pages targets resolve with 200
 # (only meaningful AFTER the deref branch is merged and Pages has redeployed):
-HTACCESS=/path/to/semanticarts.htaccess CHECK_TARGETS=1 tools/htaccess-test/run-tests.sh
+HTACCESS=../w3id.org/semanticarts/.htaccess CHECK_TARGETS=1 tools/htaccess-test/run-tests.sh
 ```
 
 Exit code is `0` only when every check passes, so it works in CI too.
 
 ### Useful overrides
 
-- `HTACCESS` (**required**) — path to the `semanticarts.htaccess` under test.
+- `HTACCESS` (**required**) — path to the `semanticarts.htaccess` under test
+  (relative or absolute; typically `../w3id.org/semanticarts/.htaccess`).
 - `PORT` (default `8080`) — host port for the test Apache.
 - `PAGES_BASE` (default `https://semanticarts.github.io/gist-doc`) — expected redirect base / target host.
 - `CHECK_TARGETS` (default `0`) — `1` = also verify the live Pages files resolve (200).

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -23,9 +23,10 @@ header** without following the redirect:
 - A realistic browser `Accept` header routes to the WIDOCO HTML.
 - Namespace IRI (`/ns/ontology/gist` with and without a trailing slash) → 302.
 - Whole-ontology IRIs (`/ontology/gistCore14.1.0`, plus the explicit-extension
-  pass-through) → Semantic Arts server / WIDOCO.
-- The catch-all (anything else, e.g. the `ns/data/gist/` namespace) → 302
-  pass-through to the Semantic Arts server.
+  pass-through) → Semantic Arts server / WIDOCO. The redirect target preserves
+  the full request path, including the leading `ontology/` segment.
+- The catch-all (anything else, e.g. the `ns/data/gist/` namespace) → 303 to a
+  Turtle file on the Semantic Arts server, preserving the request path.
 
 ## Requirements
 

--- a/tools/htaccess-test/README.md
+++ b/tools/htaccess-test/README.md
@@ -59,11 +59,14 @@ VERSION=14.1.0 NAMES=gistCore    tools/htaccess-test/check-live-deref.sh
 - Needs **internet**, not Docker or the `HTACCESS` file — it tests the *deployed*
   rules, so run it after a w3id.org change lands. Good as a CI/cron canary.
 - Env: `NAMES` (space-separated modules, default `gistCore`), `VERSION` (default
-  `14.1.0`), `IRI_BASE`, `TIMEOUT`.
-- Body validators are **optional**: `rdflib` under `python3`/`python`
-  (Turtle/RDF-XML/JSON-LD, `pip install rdflib`) or `jq` (JSON-LD only). Missing
-  validators downgrade a body check to `PASS*`/`WARN`, never a FAIL. On
-  Windows/Git Bash the interpreter is usually `python`, which is detected too.
+  `14.1.0`), `IRI_BASE`, `TIMEOUT`, `PYTHON` (interpreter with rdflib; see below).
+- Body validators are **optional**: `rdflib` (Turtle/RDF-XML/JSON-LD,
+  `pip install rdflib`) or `jq` (JSON-LD only). Missing validators downgrade a
+  body check to `PASS*`/`WARN`, never a FAIL. The script probes `python3`,
+  `python`, then the Windows `py` launcher and keeps the first that can
+  `import rdflib`. When several Pythons coexist and the one on PATH lacks rdflib
+  (e.g. MSYS2's `python` vs a native `C:\Python` install), point `PYTHON` at the
+  right one: `PYTHON=/c/Python/Python313/python.exe ...check-live-deref.sh`.
 - Exit codes: `0` all passed · `1` a real failure (final 404, bad body, or the
   signature) · `2` could not run (w3id.org itself unreachable). Cases that are
   **network-unreachable** (e.g. a firewalled runner with no route to GitHub

--- a/tools/htaccess-test/check-live-deref.sh
+++ b/tools/htaccess-test/check-live-deref.sh
@@ -32,7 +32,9 @@
 #   NAMES="gistCore gistMediaTypes" ./check-live-deref.sh         # multiple modules
 #   VERSION=14.1.0 NAMES=gistCore ./check-live-deref.sh
 #
-# Env overrides: NAMES, VERSION, IRI_BASE, TIMEOUT
+# Env overrides: NAMES, VERSION, IRI_BASE, TIMEOUT, PYTHON (path/name of a
+# Python interpreter that has rdflib — useful when several Pythons coexist and
+# the one on PATH lacks it, e.g. MSYS2 python vs a native C:\Python install).
 #
 # Exit codes: 0 = all checks passed; 1 = a real failure (final 404, wrong
 # content, or the alias-missing signature); 2 = could not run (e.g. w3id.org
@@ -57,12 +59,23 @@ ylw()  { printf '\033[33m%s\033[0m' "$1"; }
 
 command -v curl >/dev/null || { echo "ERROR: curl not found" >&2; exit 2; }
 
-# Body validators (optional). Detect once. Prefer python3, fall back to python
-# (Windows/Git Bash usually ships the interpreter as `python`, not `python3`).
-PYTHON=""
-for p in python3 python; do command -v "$p" >/dev/null 2>&1 && { PYTHON="$p"; break; }; done
+# Body validators (optional). Pick a Python that actually has rdflib — not just
+# the first `python` on PATH. On Windows/Git Bash several interpreters commonly
+# coexist (MSYS2's /mingw64/bin/python, the Windows `py` launcher, a native
+# C:\Python\... install) and only one may have rdflib installed. Honor an
+# explicit PYTHON override, else probe candidates and keep the first that can
+# `import rdflib`. `py` is the Windows launcher, usually pointing at the native
+# install where `pip install rdflib` lands.
 HAVE_RDFLIB=0
-[[ -n "${PYTHON}" ]] && "${PYTHON}" -c 'import rdflib' >/dev/null 2>&1 && HAVE_RDFLIB=1
+if [[ -n "${PYTHON:-}" ]]; then
+  "${PYTHON}" -c 'import rdflib' >/dev/null 2>&1 && HAVE_RDFLIB=1
+else
+  PYTHON=""
+  for p in python3 python py; do
+    command -v "$p" >/dev/null 2>&1 || continue
+    if "$p" -c 'import rdflib' >/dev/null 2>&1; then PYTHON="$p"; HAVE_RDFLIB=1; break; fi
+  done
+fi
 HAVE_JQ=0
 command -v jq >/dev/null 2>&1 && HAVE_JQ=1
 

--- a/tools/htaccess-test/check-live-deref.sh
+++ b/tools/htaccess-test/check-live-deref.sh
@@ -1,53 +1,80 @@
 #!/usr/bin/env bash
 #
-# LIVE end-to-end regression test for the deployed semanticarts.htaccess rules.
+# LIVE resolution check for the whole-ontology semanticarts.htaccess targets.
 #
-# Unlike run-tests.sh (which stands up a local Apache and checks only the FIRST
-# redirect hop, offline), this script hits the real IRIs on w3id.org, FOLLOWS
-# every redirect to completion, and asserts a final 200 whose body actually
-# parses in the negotiated format.
+# Two modes verify the SAME whole-ontology files at the two moments that matter:
+#
+#   MODE=targets (PRE-deploy)  — hit the origin files DIRECTLY on
+#     ontologies.semanticarts.com (…/ontology/gistCore.rdf, .ttl, .jsonld, plus
+#     the versioned files and the WIDOCO docs). This answers "do the files the
+#     new .htaccess will point at actually exist yet?" BEFORE you deploy the
+#     rules — you cannot go through w3id.org yet because the new rules aren't
+#     live. This is the check that would have caught the /gistCore.rdf incident
+#     up front.
+#
+#   MODE=deref (POST-deploy, default) — hit the real IRIs on w3id.org, FOLLOW
+#     every redirect to completion, and assert a final 200 whose body parses.
+#     This verifies the deployed rule AND its destination together. Unlike
+#     run-tests.sh (local Apache, FIRST redirect hop only, offline), it follows
+#     the w3id.org -> SA-server chain through to the real 200.
 #
 # Why this exists: the /gistCore.rdf incident. The .htaccess redirect fired
 # correctly (303/302 with a good Location), so run-tests.sh passed — but the
 # final destination on ontologies.semanticarts.com 404'd because the unversioned
 # "latest" alias file wasn't published there. Checking only the redirect hop, or
-# only the per-term files on GitHub Pages, cannot catch that. This test follows
-# the w3id.org -> SA-server chain through to the real 200.
+# only the per-term files on GitHub Pages, cannot catch that.
 #
-# It targets the UNVERSIONED alias (…/ontology/gistCore) — the resource that
-# went missing — and pairs it with the VERSIONED pass-through (gistCore14.1.0.*)
-# as a control. If the unversioned cases 404 at the final hop while the versioned
-# ones succeed, that is the exact incident signature and is flagged as such.
+# Both modes target the UNVERSIONED alias (gistCore.*) — the resource that went
+# missing — and pair it with the VERSIONED file (gistCore14.1.0.*) as a control.
+# If the unversioned cases 404 while the versioned ones succeed, that is the
+# exact incident signature and is flagged as such.
 #
 # Requirements:
 #   - curl
-#   - internet access to w3id.org, ontologies.semanticarts.com, and (for the
-#     HTML/WIDOCO branch) semanticarts.github.io
-#   - OPTIONAL body validators: python3 + rdflib (Turtle/RDF-XML/JSON-LD),
+#   - internet access to ontologies.semanticarts.com and semanticarts.github.io
+#     (targets mode), plus w3id.org (deref mode)
+#   - OPTIONAL body validators: python3/python + rdflib (Turtle/RDF-XML/JSON-LD),
 #     or jq (well-formed JSON-LD). Missing validators downgrade a body check to
 #     a WARN, never a FAIL.
 #
 # Usage:
-#   tools/htaccess-test/check-live-deref.sh                       # gistCore, v14.1.0
-#   NAMES="gistCore gistMediaTypes" ./check-live-deref.sh         # multiple modules
+#   # PRE-deploy: do the target files exist on the origin?
+#   MODE=targets tools/htaccess-test/check-live-deref.sh
+#   MODE=targets NAMES="gistCore gistMediaTypes" ./check-live-deref.sh
+#
+#   # POST-deploy: does the live w3id.org chain resolve end to end?
+#   tools/htaccess-test/check-live-deref.sh
 #   VERSION=14.1.0 NAMES=gistCore ./check-live-deref.sh
 #
-# Env overrides: NAMES, VERSION, IRI_BASE, TIMEOUT, PYTHON (path/name of a
-# Python interpreter that has rdflib — useful when several Pythons coexist and
-# the one on PATH lacks it, e.g. MSYS2 python vs a native C:\Python install).
+# Env overrides: MODE (targets|deref, default deref), NAMES, VERSION, IRI_BASE
+# (deref base), TARGET_BASE (origin whole-ontology dir, targets mode),
+# HTML_TARGET (WIDOCO docs URL), TIMEOUT, PYTHON (path/name of a Python
+# interpreter that has rdflib — useful when several Pythons coexist and the one
+# on PATH lacks it, e.g. MSYS2 python vs a native C:\Python install).
 #
-# Exit codes: 0 = all checks passed; 1 = a real failure (final 404, wrong
-# content, or the alias-missing signature); 2 = could not run (e.g. w3id.org
-# itself unreachable). Cases that are UNREACHABLE due to the network — as
-# opposed to a real 404 from the server — are reported as WARN, not FAIL, so a
-# firewalled runner (e.g. a container with no route to GitHub Pages) does not
-# produce false failures.
+# Exit codes: 0 = all checks passed; 1 = a real failure (404, wrong content, or
+# the alias-missing signature); 2 = could not run (base host unreachable). Cases
+# that are UNREACHABLE due to the network — as opposed to a real 404 from the
+# server — are reported as WARN, not FAIL, so a firewalled runner (e.g. a
+# container with no route to GitHub Pages) does not produce false failures.
 set -uo pipefail
 
+MODE="${MODE:-deref}"                 # targets = pre-deploy origin check; deref = post-deploy
 NAMES="${NAMES:-gistCore}"
 VERSION="${VERSION:-14.1.0}"
 IRI_BASE="${IRI_BASE:-https://w3id.org/semanticarts/ontology}"
+# Where the whole-ontology files actually live — what the .htaccess redirects
+# to. Checked directly in targets (pre-deploy) mode.
+TARGET_BASE="${TARGET_BASE:-https://ontologies.semanticarts.com/ontology}"
+# The WIDOCO docs the HTML branch resolves to (the "latest" docs, shared across
+# modules under the current rules).
+HTML_TARGET="${HTML_TARGET:-https://semanticarts.github.io/gist-doc/latest/widoco-documentation/index-en.html}"
 TIMEOUT="${TIMEOUT:-20}"
+
+case "${MODE}" in
+  targets|deref) ;;
+  *) echo "ERROR: MODE must be 'targets' or 'deref', got '${MODE}'" >&2; exit 2 ;;
+esac
 
 # Browser-style Accept header (what Chrome/Firefox send). Contains
 # application/xml and */* but must still route to HTML, so keep it verbatim.
@@ -136,7 +163,9 @@ PY
 
 # check <desc> <url> <accept> <want_format> <bucket> <name>
 #   want_format: turtle|rdfxml|jsonld|html
-#   bucket:      "unversioned" | "versioned" (for the signature assertion)
+#   bucket:      "unversioned" | "versioned" | "none" — feeds the alias-missing
+#                signature. Use "none" for the HTML/WIDOCO case: it is not one of
+#                the SA-server alias files, so it must not trip the signature.
 check() {
   local desc="$1" url="$2" accept="$3" fmt="$4" bucket="$5" name="$6"
   local res code ct rc
@@ -180,32 +209,58 @@ check() {
   rm -f "${BODY_FILE}"
 }
 
-echo "==> Live deref regression test"
-echo "    base=${IRI_BASE}  names='${NAMES}'  version=${VERSION}"
+if [[ "${MODE}" == "targets" ]]; then
+  echo "==> Pre-deploy origin target check (do the whole-ontology files exist?)"
+  echo "    base=${TARGET_BASE}  names='${NAMES}'  version=${VERSION}"
+  GUARD_URL="${TARGET_BASE}/${NAMES%% *}.ttl"; GUARD_HOST="${TARGET_BASE}"
+else
+  echo "==> Post-deploy live deref check (does the w3id.org chain resolve?)"
+  echo "    base=${IRI_BASE}  names='${NAMES}'  version=${VERSION}"
+  GUARD_URL="${IRI_BASE}/${NAMES%% *}"; GUARD_HOST="${IRI_BASE}"
+fi
 
-# Guard: if w3id.org itself is unreachable, we cannot run at all.
-gc="$(curl -sL -m "${TIMEOUT}" -o /dev/null -w '%{http_code}' "${IRI_BASE}/${NAMES%% *}" 2>/dev/null || echo 000)"
+# Guard: if the base host itself is unreachable (http 000), we cannot run at all
+# — distinct from a real 404, which is a legitimate finding.
+gc="$(curl -sL -m "${TIMEOUT}" -o /dev/null -w '%{http_code}' "${GUARD_URL}" 2>/dev/null || echo 000)"
 if [[ "${gc}" == "000" ]]; then
-  echo "ERROR: cannot reach ${IRI_BASE} (http 000). Check network. Aborting." >&2
+  echo "ERROR: cannot reach ${GUARD_HOST} (http 000). Check network. Aborting." >&2
   exit 2
 fi
 
 for name in ${NAMES}; do
-  U="${IRI_BASE}/${name}"
-  echo
-  echo "== Unversioned alias: ${U} =="
-  check "rdf+xml -> 200 valid RDF/XML"          "${U}" "application/rdf+xml" rdfxml unversioned "${name}"
-  check "turtle  -> 200 valid Turtle"           "${U}" "text/turtle"         turtle unversioned "${name}"
-  check "ld+json -> 200 valid JSON-LD"          "${U}" "application/ld+json" jsonld unversioned "${name}"
-  check "browser -> 200 WIDOCO HTML"            "${U}" "${BROWSER_ACCEPT}"   html   unversioned "${name}"
-  check "*/*     -> 200 Turtle (default)"       "${U}" "*/*"                 turtle unversioned "${name}"
-  check "no Accept -> 200 Turtle (default)"     "${U}" "-"                   turtle unversioned "${name}"
+  if [[ "${MODE}" == "targets" ]]; then
+    T="${TARGET_BASE}/${name}"
+    echo
+    echo "== Unversioned origin files (direct): ${T}.{rdf,ttl,jsonld} =="
+    # Requested by explicit extension; no content negotiation happens here — we
+    # are asking the origin whether each concrete file exists and is valid.
+    check "rdf+xml file exists + valid RDF/XML"  "${T}.rdf"    "*/*" rdfxml unversioned "${name}"
+    check "turtle  file exists + valid Turtle"   "${T}.ttl"    "*/*" turtle unversioned "${name}"
+    check "ld+json file exists + valid JSON-LD"  "${T}.jsonld" "*/*" jsonld unversioned "${name}"
+    check "WIDOCO docs exist (HTML)"             "${HTML_TARGET}" "*/*" html none "${name}"
 
-  echo
-  echo "== Versioned pass-through: ${U}${VERSION}.{ttl,rdf,jsonld} (control) =="
-  check "${VERSION}.ttl    -> 200 valid Turtle"   "${U}${VERSION}.ttl"    "*/*" turtle versioned "${name}"
-  check "${VERSION}.rdf    -> 200 valid RDF/XML"  "${U}${VERSION}.rdf"    "*/*" rdfxml versioned "${name}"
-  check "${VERSION}.jsonld -> 200 valid JSON-LD"  "${U}${VERSION}.jsonld" "*/*" jsonld versioned "${name}"
+    echo
+    echo "== Versioned origin files (control): ${T}${VERSION}.{ttl,rdf,jsonld} =="
+    check "${VERSION}.ttl    exists + valid Turtle"   "${T}${VERSION}.ttl"    "*/*" turtle versioned "${name}"
+    check "${VERSION}.rdf    exists + valid RDF/XML"  "${T}${VERSION}.rdf"    "*/*" rdfxml versioned "${name}"
+    check "${VERSION}.jsonld exists + valid JSON-LD"  "${T}${VERSION}.jsonld" "*/*" jsonld versioned "${name}"
+  else
+    U="${IRI_BASE}/${name}"
+    echo
+    echo "== Unversioned alias: ${U} =="
+    check "rdf+xml -> 200 valid RDF/XML"          "${U}" "application/rdf+xml" rdfxml unversioned "${name}"
+    check "turtle  -> 200 valid Turtle"           "${U}" "text/turtle"         turtle unversioned "${name}"
+    check "ld+json -> 200 valid JSON-LD"          "${U}" "application/ld+json" jsonld unversioned "${name}"
+    check "browser -> 200 WIDOCO HTML"            "${U}" "${BROWSER_ACCEPT}"   html   none        "${name}"
+    check "*/*     -> 200 Turtle (default)"       "${U}" "*/*"                 turtle unversioned "${name}"
+    check "no Accept -> 200 Turtle (default)"     "${U}" "-"                   turtle unversioned "${name}"
+
+    echo
+    echo "== Versioned pass-through: ${U}${VERSION}.{ttl,rdf,jsonld} (control) =="
+    check "${VERSION}.ttl    -> 200 valid Turtle"   "${U}${VERSION}.ttl"    "*/*" turtle versioned "${name}"
+    check "${VERSION}.rdf    -> 200 valid RDF/XML"  "${U}${VERSION}.rdf"    "*/*" rdfxml versioned "${name}"
+    check "${VERSION}.jsonld -> 200 valid JSON-LD"  "${U}${VERSION}.jsonld" "*/*" jsonld versioned "${name}"
+  fi
 done
 
 echo
@@ -218,15 +273,20 @@ sig=0
 for name in ${NAMES}; do
   if [[ "${UNVERSIONED_404[$name]:-0}" == "1" && "${VERSIONED_OK[$name]:-0}" == "1" ]]; then
     printf '  %s  unversioned latest alias missing on ontologies.semanticarts.com: %s\n' "$(red SIGNATURE)" "${name}"
-    printf '        (versioned %s%s.* resolves, but unversioned %s 404s at the final hop)\n' "${name}" "${VERSION}" "${name}"
+    if [[ "${MODE}" == "targets" ]]; then
+      printf '        (versioned %s%s.* exists on the origin, but unversioned %s.* does NOT — publish it BEFORE deploying)\n' "${name}" "${VERSION}" "${name}"
+    else
+      printf '        (versioned %s%s.* resolves, but unversioned %s 404s at the final hop)\n' "${name}" "${VERSION}" "${name}"
+    fi
     sig=1
   fi
 done
 
-printf 'Live deref: %s passed, %s failed, %s warnings\n' \
+label="Live deref"; [[ "${MODE}" == "targets" ]] && label="Origin targets"
+printf '%s: %s passed, %s failed, %s warnings\n' "${label}" \
   "$(grn ${pass})" "$([[ ${fail} -eq 0 ]] && grn 0 || red ${fail})" "$(ylw ${warn})"
 
 echo
-[[ ${fail} -eq 0 ]] && { echo "$(grn 'ALL LIVE CHECKS PASSED')"; exit 0; }
+[[ ${fail} -eq 0 ]] && { echo "$(grn 'ALL CHECKS PASSED')"; exit 0; }
 [[ ${sig} -eq 1 ]] && echo "$(red 'INCIDENT SIGNATURE DETECTED — see SIGNATURE lines above')"
-echo "$(red 'SOME LIVE CHECKS FAILED')"; exit 1
+echo "$(red 'SOME CHECKS FAILED')"; exit 1

--- a/tools/htaccess-test/check-live-deref.sh
+++ b/tools/htaccess-test/check-live-deref.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# LIVE end-to-end regression test for the deployed semanticarts.htaccess rules.
+#
+# Unlike run-tests.sh (which stands up a local Apache and checks only the FIRST
+# redirect hop, offline), this script hits the real IRIs on w3id.org, FOLLOWS
+# every redirect to completion, and asserts a final 200 whose body actually
+# parses in the negotiated format.
+#
+# Why this exists: the /gistCore.rdf incident. The .htaccess redirect fired
+# correctly (303/302 with a good Location), so run-tests.sh passed — but the
+# final destination on ontologies.semanticarts.com 404'd because the unversioned
+# "latest" alias file wasn't published there. Checking only the redirect hop, or
+# only the per-term files on GitHub Pages, cannot catch that. This test follows
+# the w3id.org -> SA-server chain through to the real 200.
+#
+# It targets the UNVERSIONED alias (…/ontology/gistCore) — the resource that
+# went missing — and pairs it with the VERSIONED pass-through (gistCore14.1.0.*)
+# as a control. If the unversioned cases 404 at the final hop while the versioned
+# ones succeed, that is the exact incident signature and is flagged as such.
+#
+# Requirements:
+#   - curl
+#   - internet access to w3id.org, ontologies.semanticarts.com, and (for the
+#     HTML/WIDOCO branch) semanticarts.github.io
+#   - OPTIONAL body validators: python3 + rdflib (Turtle/RDF-XML/JSON-LD),
+#     or jq (well-formed JSON-LD). Missing validators downgrade a body check to
+#     a WARN, never a FAIL.
+#
+# Usage:
+#   tools/htaccess-test/check-live-deref.sh                       # gistCore, v14.1.0
+#   NAMES="gistCore gistMediaTypes" ./check-live-deref.sh         # multiple modules
+#   VERSION=14.1.0 NAMES=gistCore ./check-live-deref.sh
+#
+# Env overrides: NAMES, VERSION, IRI_BASE, TIMEOUT
+#
+# Exit codes: 0 = all checks passed; 1 = a real failure (final 404, wrong
+# content, or the alias-missing signature); 2 = could not run (e.g. w3id.org
+# itself unreachable). Cases that are UNREACHABLE due to the network — as
+# opposed to a real 404 from the server — are reported as WARN, not FAIL, so a
+# firewalled runner (e.g. a container with no route to GitHub Pages) does not
+# produce false failures.
+set -uo pipefail
+
+NAMES="${NAMES:-gistCore}"
+VERSION="${VERSION:-14.1.0}"
+IRI_BASE="${IRI_BASE:-https://w3id.org/semanticarts/ontology}"
+TIMEOUT="${TIMEOUT:-20}"
+
+# Browser-style Accept header (what Chrome/Firefox send). Contains
+# application/xml and */* but must still route to HTML, so keep it verbatim.
+BROWSER_ACCEPT='text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
+
+red()  { printf '\033[31m%s\033[0m' "$1"; }
+grn()  { printf '\033[32m%s\033[0m' "$1"; }
+ylw()  { printf '\033[33m%s\033[0m' "$1"; }
+
+command -v curl >/dev/null || { echo "ERROR: curl not found" >&2; exit 2; }
+
+# Body validators (optional). Detect once. Prefer python3, fall back to python
+# (Windows/Git Bash usually ships the interpreter as `python`, not `python3`).
+PYTHON=""
+for p in python3 python; do command -v "$p" >/dev/null 2>&1 && { PYTHON="$p"; break; }; done
+HAVE_RDFLIB=0
+[[ -n "${PYTHON}" ]] && "${PYTHON}" -c 'import rdflib' >/dev/null 2>&1 && HAVE_RDFLIB=1
+HAVE_JQ=0
+command -v jq >/dev/null 2>&1 && HAVE_JQ=1
+
+pass=0; fail=0; warn=0
+
+# Track, per name, whether a real final-hop 404 was seen on an unversioned case
+# and whether the versioned control succeeded — that pairing is the incident
+# signature.
+declare -A UNVERSIONED_404
+declare -A VERSIONED_OK
+
+# fetch <url> <accept>  ->  prints "<http_code>\t<content_type>\t<curl_exit>" and
+# writes the response body to the pre-existing $BODY_FILE. accept='-' sends no
+# Accept header. NOTE: fetch is called inside $(...) (a subshell), so it must NOT
+# create $BODY_FILE itself — the name would not survive back to the caller. The
+# caller (check) creates the temp file; curl -o writes to that real path, which
+# the parent can then read.
+BODY_FILE=""
+fetch() {
+  local url="$1" accept="$2"
+  local -a hdr=(-H "Accept: ${accept}")
+  [[ "${accept}" == "-" ]] && hdr=(-H "Accept:")
+  local out code ct rc
+  out="$(curl -sL -m "${TIMEOUT}" "${hdr[@]}" -o "${BODY_FILE}" \
+        -w '%{http_code}\t%{content_type}' "${url}" 2>/dev/null)"
+  rc=$?
+  code="${out%%$'\t'*}"
+  ct="${out##*$'\t'}"
+  printf '%s\t%s\t%s' "${code}" "${ct}" "${rc}"
+}
+
+# validate_body <format>  (turtle|rdfxml|jsonld|html) -> 0 ok, 1 invalid, 2 skip
+validate_body() {
+  local fmt="$1"
+  case "${fmt}" in
+    turtle|rdfxml|jsonld)
+      if [[ "${HAVE_RDFLIB}" == "1" ]]; then
+        local rf=turtle
+        [[ "${fmt}" == "rdfxml" ]] && rf=xml
+        [[ "${fmt}" == "jsonld" ]] && rf=json-ld
+        "${PYTHON}" - "$BODY_FILE" "$rf" <<'PY' >/dev/null 2>&1
+import sys, rdflib
+g = rdflib.Graph()
+g.parse(sys.argv[1], format=sys.argv[2])
+assert len(g) > 0
+PY
+        return $(( $? == 0 ? 0 : 1 ))
+      fi
+      if [[ "${fmt}" == "jsonld" && "${HAVE_JQ}" == "1" ]]; then
+        jq -e . "${BODY_FILE}" >/dev/null 2>&1 && return 0 || return 1
+      fi
+      return 2 ;;
+    html)
+      grep -qi '<html' "${BODY_FILE}" && return 0 || return 1 ;;
+  esac
+  return 2
+}
+
+# check <desc> <url> <accept> <want_format> <bucket> <name>
+#   want_format: turtle|rdfxml|jsonld|html
+#   bucket:      "unversioned" | "versioned" (for the signature assertion)
+check() {
+  local desc="$1" url="$2" accept="$3" fmt="$4" bucket="$5" name="$6"
+  local res code ct rc
+  BODY_FILE="$(mktemp)"
+  res="$(fetch "${url}" "${accept}")"
+  code="${res%%$'\t'*}"; rc="${res##*$'\t'}"
+  ct="$(printf '%s' "${res}" | cut -f2)"
+
+  # Network could not complete the chain (curl error or 000). Not a server 404 —
+  # report WARN so a firewalled runner doesn't fail spuriously.
+  if [[ "${rc}" != "0" || "${code}" == "000" ]]; then
+    printf '  %s  %s\n' "$(ylw WARN)" "${desc}"
+    printf '        unreachable (curl exit %s, http %s) — network, not a server 404\n' "${rc}" "${code}"
+    warn=$((warn+1)); rm -f "${BODY_FILE}"; return
+  fi
+
+  if [[ "${code}" != "200" ]]; then
+    printf '  %s  %s\n' "$(red FAIL)" "${desc}"
+    printf '        expected final 200 %s, got %s (ct=%s)\n' "${fmt}" "${code}" "${ct}"
+    fail=$((fail+1))
+    [[ "${bucket}" == "unversioned" && "${code}" == "404" ]] && UNVERSIONED_404["${name}"]=1
+    rm -f "${BODY_FILE}"; return
+  fi
+
+  # 200 — now validate the body.
+  local v; validate_body "${fmt}"; v=$?
+  if [[ "${v}" == "0" ]]; then
+    printf '  %s  %s\n' "$(grn PASS)" "${desc}"
+    pass=$((pass+1))
+    [[ "${bucket}" == "versioned" ]] && VERSIONED_OK["${name}"]=1
+  elif [[ "${v}" == "2" ]]; then
+    printf '  %s  %s\n' "$(ylw PASS*)" "${desc}"
+    printf '        200 OK; body parse skipped (no validator for %s)\n' "${fmt}"
+    pass=$((pass+1)); warn=$((warn+1))
+    [[ "${bucket}" == "versioned" ]] && VERSIONED_OK["${name}"]=1
+  else
+    printf '  %s  %s\n' "$(red FAIL)" "${desc}"
+    printf '        200 but body did NOT parse as %s (ct=%s)\n' "${fmt}" "${ct}"
+    fail=$((fail+1))
+  fi
+  rm -f "${BODY_FILE}"
+}
+
+echo "==> Live deref regression test"
+echo "    base=${IRI_BASE}  names='${NAMES}'  version=${VERSION}"
+
+# Guard: if w3id.org itself is unreachable, we cannot run at all.
+gc="$(curl -sL -m "${TIMEOUT}" -o /dev/null -w '%{http_code}' "${IRI_BASE}/${NAMES%% *}" 2>/dev/null || echo 000)"
+if [[ "${gc}" == "000" ]]; then
+  echo "ERROR: cannot reach ${IRI_BASE} (http 000). Check network. Aborting." >&2
+  exit 2
+fi
+
+for name in ${NAMES}; do
+  U="${IRI_BASE}/${name}"
+  echo
+  echo "== Unversioned alias: ${U} =="
+  check "rdf+xml -> 200 valid RDF/XML"          "${U}" "application/rdf+xml" rdfxml unversioned "${name}"
+  check "turtle  -> 200 valid Turtle"           "${U}" "text/turtle"         turtle unversioned "${name}"
+  check "ld+json -> 200 valid JSON-LD"          "${U}" "application/ld+json" jsonld unversioned "${name}"
+  check "browser -> 200 WIDOCO HTML"            "${U}" "${BROWSER_ACCEPT}"   html   unversioned "${name}"
+  check "*/*     -> 200 Turtle (default)"       "${U}" "*/*"                 turtle unversioned "${name}"
+  check "no Accept -> 200 Turtle (default)"     "${U}" "-"                   turtle unversioned "${name}"
+
+  echo
+  echo "== Versioned pass-through: ${U}${VERSION}.{ttl,rdf,jsonld} (control) =="
+  check "${VERSION}.ttl    -> 200 valid Turtle"   "${U}${VERSION}.ttl"    "*/*" turtle versioned "${name}"
+  check "${VERSION}.rdf    -> 200 valid RDF/XML"  "${U}${VERSION}.rdf"    "*/*" rdfxml versioned "${name}"
+  check "${VERSION}.jsonld -> 200 valid JSON-LD"  "${U}${VERSION}.jsonld" "*/*" jsonld versioned "${name}"
+done
+
+echo
+echo "------------------------------------------------------------"
+
+# Incident signature: unversioned final-hop 404 while the versioned control for
+# the same module resolves. Distinguishes the "latest alias missing" failure
+# from a generic redirect-rule break (which would fail the versioned case too).
+sig=0
+for name in ${NAMES}; do
+  if [[ "${UNVERSIONED_404[$name]:-0}" == "1" && "${VERSIONED_OK[$name]:-0}" == "1" ]]; then
+    printf '  %s  unversioned latest alias missing on ontologies.semanticarts.com: %s\n' "$(red SIGNATURE)" "${name}"
+    printf '        (versioned %s%s.* resolves, but unversioned %s 404s at the final hop)\n' "${name}" "${VERSION}" "${name}"
+    sig=1
+  fi
+done
+
+printf 'Live deref: %s passed, %s failed, %s warnings\n' \
+  "$(grn ${pass})" "$([[ ${fail} -eq 0 ]] && grn 0 || red ${fail})" "$(ylw ${warn})"
+
+echo
+[[ ${fail} -eq 0 ]] && { echo "$(grn 'ALL LIVE CHECKS PASSED')"; exit 0; }
+[[ ${sig} -eq 1 ]] && echo "$(red 'INCIDENT SIGNATURE DETECTED — see SIGNATURE lines above')"
+echo "$(red 'SOME LIVE CHECKS FAILED')"; exit 1

--- a/tools/htaccess-test/run-tests.sh
+++ b/tools/htaccess-test/run-tests.sh
@@ -14,9 +14,10 @@
 #   - curl
 #
 # semanticarts.htaccess is intentionally NOT stored in this repo (it is deployed
-# to the w3id.org repo), so point the harness at your working copy:
+# to the w3id.org repo), so point the harness at your working copy. Relative or
+# absolute paths both work (the path is resolved to absolute before mounting):
 #
-#   HTACCESS=/path/to/semanticarts.htaccess tools/htaccess-test/run-tests.sh
+#   HTACCESS=../w3id.org/semanticarts/.htaccess tools/htaccess-test/run-tests.sh
 #
 # Usage:
 #   HTACCESS=... tools/htaccess-test/run-tests.sh                  # routing tests (no internet needed*)
@@ -46,19 +47,40 @@ BROWSER_ACCEPT='text/html,application/xhtml+xml,application/xml;q=0.9,image/avif
 red() { printf '\033[31m%s\033[0m' "$1"; }
 grn() { printf '\033[32m%s\033[0m' "$1"; }
 
+# Docker bind mounts require an ABSOLUTE path. A relative one (e.g.
+# ../w3id.org/semanticarts/.htaccess) silently mounts as an empty directory, so
+# Apache loads no rewrite rules and every request 404s. Resolve it up front.
+if [[ -f "${HTACCESS}" ]]; then
+  HTACCESS="$(cd "$(dirname "${HTACCESS}")" && pwd)/$(basename "${HTACCESS}")"
+fi
+
 if [[ ! -f "${HTACCESS}" ]]; then
   cat >&2 <<EOF
 ERROR: semanticarts.htaccess not found at:
   ${HTACCESS}
 
 This file is intentionally not stored in the gist-doc repo (it is deployed to
-the w3id.org repo). Point the harness at your working copy with HTACCESS:
+the w3id.org repo's semanticarts/.htaccess). Point the harness at your working
+copy with HTACCESS (relative or absolute path both work):
 
-  HTACCESS=/path/to/semanticarts.htaccess ${0}
+  HTACCESS=../w3id.org/semanticarts/.htaccess ${0}
 EOF
   exit 2
 fi
 command -v docker >/dev/null || { echo "ERROR: docker not found" >&2; exit 2; }
+
+# On Git Bash / MSYS (Windows), the shell rewrites Unix-style command arguments
+# into Windows paths. That mangles the container-side bind-mount target
+# (/usr/local/apache2/htdocs/.htaccess -> C:\Program Files\Git\usr\local\...),
+# so the file lands nowhere Apache looks and every request 404s. Disable that
+# conversion for the docker calls and hand Docker a Windows-form host path.
+DOCKER_HTACCESS="${HTACCESS}"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    export MSYS_NO_PATHCONV=1
+    command -v cygpath >/dev/null 2>&1 && DOCKER_HTACCESS="$(cygpath -m "${HTACCESS}")"
+    ;;
+esac
 
 cleanup() { docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
@@ -66,7 +88,7 @@ trap cleanup EXIT
 echo "==> Starting Apache (httpd:2.4) with semanticarts.htaccess at the doc root..."
 cleanup
 docker run -d --name "${CONTAINER}" -p "${PORT}:80" \
-  -v "${HTACCESS}:/usr/local/apache2/htdocs/.htaccess:ro" \
+  -v "${DOCKER_HTACCESS}:/usr/local/apache2/htdocs/.htaccess:ro" \
   httpd:2.4 \
   bash -c "
     sed -i 's|^#LoadModule rewrite_module|LoadModule rewrite_module|' conf/httpd.conf

--- a/tools/htaccess-test/run-tests.sh
+++ b/tools/htaccess-test/run-tests.sh
@@ -157,17 +157,22 @@ assert_redirect "trailing slash -> Namespace.html"  "ns/ontology/gist/" "*/*" 30
 
 echo
 echo "== Whole-ontology IRI: /ontology/gistCore14.1.0 =="
-assert_redirect "explicit .ttl -> server (pass-through)" "ontology/gistCore14.1.0.ttl" "text/turtle" 303 "${O}/gistCore14.1.0.ttl"
-assert_redirect "turtle  -> server .ttl"            "ontology/gistCore14.1.0" "text/turtle"          303 "${O}/gistCore14.1.0.ttl"
-assert_redirect "rdf+xml -> server .rdf"            "ontology/gistCore14.1.0" "application/rdf+xml"   303 "${O}/gistCore14.1.0.rdf"
-assert_redirect "ld+json -> server .jsonld"         "ontology/gistCore14.1.0" "application/ld+json"   303 "${O}/gistCore14.1.0.jsonld"
+# The rewrite target preserves the full request path, including the leading
+# 'ontology/' segment (…/ontology/gistCore14.1.0.ttl, not …/gistCore14.1.0.ttl).
+assert_redirect "explicit .ttl -> server (pass-through)" "ontology/gistCore14.1.0.ttl" "text/turtle" 303 "${O}/ontology/gistCore14.1.0.ttl"
+assert_redirect "turtle  -> server .ttl"            "ontology/gistCore14.1.0" "text/turtle"          303 "${O}/ontology/gistCore14.1.0.ttl"
+assert_redirect "rdf+xml -> server .rdf"            "ontology/gistCore14.1.0" "application/rdf+xml"   303 "${O}/ontology/gistCore14.1.0.rdf"
+assert_redirect "ld+json -> server .jsonld"         "ontology/gistCore14.1.0" "application/ld+json"   303 "${O}/ontology/gistCore14.1.0.jsonld"
 assert_redirect "html    -> widoco docs"            "ontology/gistCore14.1.0" "${BROWSER_ACCEPT}"     303 "${P}/latest/widoco-documentation/index-en.html"
-assert_redirect "*/*     -> server .ttl (default)"  "ontology/gistCore14.1.0" "*/*"                   303 "${O}/gistCore14.1.0.ttl"
+assert_redirect "*/*     -> server .ttl (default)"  "ontology/gistCore14.1.0" "*/*"                   303 "${O}/ontology/gistCore14.1.0.ttl"
 
 echo
-echo "== Catch-all pass-through: everything else -> Semantic Arts server (302) =="
-assert_redirect "bare gistCore             -> server" "gistCore"            "*/*" 302 "${O}/gistCore"
-assert_redirect "ns/data/gist/Foo (data ns) -> server" "ns/data/gist/Foo"   "*/*" 302 "${O}/ns/data/gist/Foo"
+echo "== Catch-all: everything else -> Semantic Arts server as Turtle (303) =="
+# The greedy conneg rules (^(.+)$) now match any path, and the old 302
+# pass-through is disabled — so unmatched IRIs 303 to a .ttl on the SA server,
+# preserving the request path verbatim.
+assert_redirect "bare gistCore             -> server .ttl" "gistCore"          "*/*" 303 "${O}/gistCore.ttl"
+assert_redirect "ns/data/gist/Foo (data ns) -> server .ttl" "ns/data/gist/Foo" "*/*" 303 "${O}/ns/data/gist/Foo.ttl"
 
 echo
 echo "------------------------------------------------------------"


### PR DESCRIPTION
This branch started as a Windows Git Bash fix for `run-tests.sh` and grew to add a live resolution harness that covers the failure mode behind the `/gistCore.rdf` incident.

## 1. Windows / Git Bash fix for `run-tests.sh`

**Problem:** on Windows under Git Bash, all 17 routing tests returned `404` / `Location = <none>` — the rewrite rules never fired. MSYS POSIX-path conversion rewrote the **container-side** bind-mount target `/usr/local/apache2/htdocs/.htaccess` into a Windows path, so the `.htaccess` mounted nowhere Apache looks and no rules loaded.

**Fix:** on MSYS/MINGW/Cygwin, `export MSYS_NO_PATHCONV=1` and translate the host path with `cygpath -m` for the `docker` calls (Linux/macOS unchanged); resolve `HTACCESS` to an absolute path up front (Docker bind mounts require it); README gains a Windows/Git Bash note. Tests also updated to match current rewrite behavior.

## 2. New `check-live-deref.sh` — whole-ontology resolution checks

`run-tests.sh` asserts the redirect *target* (`Location`), not that the target resolves — the exact gap behind the `/gistCore.rdf` incident, where the redirect fired correctly but the destination on `ontologies.semanticarts.com` 404'd. This script verifies the whole-ontology files actually **exist and resolve**, in two modes:

- **`MODE=targets`** (pre-deploy) — requests each origin file **directly** on `ontologies.semanticarts.com` (`gistCore.{rdf,ttl,jsonld}`, the versioned control, and the WIDOCO docs) and asserts a `200` that parses. Answers *"do the destinations the new rules will point at exist yet?"* **before** deploying.
- **`MODE=deref`** (default, post-deploy) — hits the real w3id.org IRIs, follows every redirect to a final `200`, and validates the body per negotiated format.

Both pair the **unversioned** alias with the **versioned** file as a control and flag the exact `SIGNATURE  unversioned latest alias missing on ontologies.semanticarts.com` when the alias is gone but the version resolves — distinct from a generic rule break. Body validation uses `rdflib`/`jq` when present (degrades to a warning, never a false fail; picks a Python that actually has rdflib, incl. the Windows `py` launcher, with a `PYTHON` override). Network-unreachable cases WARN rather than FAIL.

## 3. Docs

README restructured around the two tools with a pre-deploy → deploy → post-deploy workflow. Adds `.markdownlint.json` (`MD024: siblings_only`) so the intentional parallel sub-headings don't trip the linter.

## Verification

All suites green on a Windows host:

- `run-tests.sh` — **17/17**
- `check-live-deref.sh MODE=targets` — **7/7**, 0 warnings
- `check-live-deref.sh` (deref) — **9/9**, 0 warnings

The alias-missing `SIGNATURE` path was verified against a local mock (versioned 200, unversioned 404 → flagged, exit 1). This also confirmed the original `/gistCore.rdf` incident is currently resolved (all aliases resolve and parse).

Generated with Claude Code (Semantic Arts)